### PR TITLE
Validate eyedropper mousedown event

### DIFF
--- a/public/js/atlasMaker-interaction.js
+++ b/public/js/atlasMaker-interaction.js
@@ -681,6 +681,7 @@ var AtlasMakerInteraction = {
                 break;
             case 'eyedrop':
                 var value = me.eyedrop( x,y,me.User );
+                if(!value) break;
                 var index = me.ontology.valueToIndex[ value ];
                 var selRegionName = me.ontology.labels[ index ].name;
                 me.info.region = selRegionName;

--- a/public/js/atlasMaker-interaction.js
+++ b/public/js/atlasMaker-interaction.js
@@ -681,7 +681,7 @@ var AtlasMakerInteraction = {
                 break;
             case 'eyedrop':
                 var value = me.eyedrop( x,y,me.User );
-                if(!value) break;
+                if (!value) { break; }
                 var index = me.ontology.valueToIndex[ value ];
                 var selRegionName = me.ontology.labels[ index ].name;
                 me.info.region = selRegionName;


### PR DESCRIPTION
<!-- Thank you so much for your contribution to BrainBox! <3 -->

<!-- Please find a short title for your pull request and describe your changes on the following line: -->
This builds on top of PR #162, and more specifically, fixes the issue noted on https://github.com/OpenNeuroLab/BrainBox/pull/162#issuecomment-337383935.

---
<!-- Please go through our check list and check the functionalities which might be affected by your code changes. Replace each `[ ]` by `[X]` when the step is complete.-->
- [X] These changes fix PR #162 (github issue number if applicable).
- [X] All BrainBox tools behave as expected:
    * **KEYS**
        * right and left arrow keys
            - [X] jump to next or previous slice within one brain, respectively
            - [X] update the slider accordingly
            - [X] update the slice number accordingly (upper left corner of the viewer window)
        * down and up arrow keys
            - [X] jump to the next or previous brain within one project, respectively
            - [X] update the selected subject in the annotation table
    * **TOOL BUTTONS**
        * minus
            - [X] jumps to the previous slice within one brain
            - [X] updates the slider accordingly
            - [X] updates the slice number accordingly (upper left corner of the viewer window)
        * plus
            - [X] jumps to the next slice within one brain
            - [X] updates the slider accordingly
            - [X] updates the slice number accordingly (upper left corner of the viewer window)
        * slider
            - [X] updates slice view and slice number on the fly
        * show tool
            - [X] when you click and drag in your browser window, this tool displays a cirlce at the position of your mouse click & drag as well as the user name in all browser windows connected to the same brain
        * pencil tool
            - [X] draws a line in the colour displayed in the color field
            - [X] in combination with bucket tool filles a complete area with the chosen colour (be sure to have closed the contour line ;) Otherwise, the undo button will be your friend ;)
            - [X] updates length and volume information (of what has been segmented) in the upper left corner of the viewer
        * colour field
            - [X] displays the currently chosen colour to draw and fill
            - [X] on click opens the set of colours available within the chosen label set where a new 
        * eyedropper tool
            - [X] updates the colour field in the tool panel
            - [X] displays/updates the region name in the upper left corner of the viewer
        * undo tool
            - [X] undoes the user's actions in reverse chronological order and currently has the bug that it even undoes actions in slices you are currently not seeing! and there is currently no redo...
        * save button
            - [X] saves the annotation of the data set into the data base
            - [X] displays a message that user needs to login in case they are not (CHECK!)
            - [X] display a message `Atlas saved Wed Oct 18 2017 12:49:12 GMT+0200 (CEST)`


<!-- Either or. Please replace `__` with appropriate data: -->
- [ ] I implemented tests for these changes OR
- [X] These changes do not require tests because issue #157 needs to be done first for tests.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Again, many many thanks for your work! \ö/ -->

