### PR TITLE
Add empty folder "public/data" to the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,10 @@ If you want to work on BrainBox's code, you'll need a local installation:
 
 1. install and start `mongo` database
 2. clone the repo and `cd` to the brainbox directory
-3. `mkdir public/data`
 4. [create a new OAuth application](https://github.com/settings/applications/new) for your local brainbox url (http://localhost:3000 by default)
 5. paste the keys into the github-keys.json.example file, and drop the .example
 6. drop the `.example` from `blacklist.json.example`
 7. drop the `.example` from `whitelist.json.example`
 8. `npm install`
 9. `npm start`
-10. To lint your files use `npm test`, you can use `xo --fix` to fix common mistakes, before committing,
-to do that install `xo` globally using `npm i -g xo`
+10. To lint your files use `npm test`, and you can use `node_modules/.bin/xo --fix <your_file.js>` to fix common mistakes before committing

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
 cd /brainbox
-mkdir -p public
-mkdir -p public/data
 npm install
 node ./bin/www


### PR DESCRIPTION
<!-- Thank you so much for your contribution to BrainBox! <3 -->

<!-- Please find a short title for your pull request and describe your changes on the following line: -->
When installing the project I noticed that we need to manually create the `public/data` folder, but this can be skipped if we add it to the repo using the common pattern of adding an empty file called `.gitkeep` inside it.

This is a minor improvement but can save someone that forget to manually create the folder when doing the project setup 😄 

---
<!-- Please go through our check list and check the functionalities which might be affected by your code changes. Replace each `[ ]` by `[X]` when the step is complete.-->
- [x] All BrainBox tools behave as expected
            
<!-- Either or. Please replace `__` with appropriate data: -->
- [x] These changes do not require tests because it don't touch in the source code

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Again, many many thanks for your work! \ö/ -->

